### PR TITLE
Add option to sort results in iter_flow

### DIFF
--- a/laminar/laminar.py
+++ b/laminar/laminar.py
@@ -141,6 +141,7 @@ def iter_flow(function: Callable, data: Collection, *args, **kwargs) -> dict:
     """
         
     cores = kwargs.pop("cores", cpu_count())
+    sort_results = kwargs.pop("sort_results", False)
     
     if cores > cpu_count():
         cores = cpu_count()
@@ -157,11 +158,13 @@ def iter_flow(function: Callable, data: Collection, *args, **kwargs) -> dict:
     
     processes = []    
     
+    ordered_names = []
     end = -1
     for dataset in data_split:
         start = end + 1
         end += len(dataset)
         name = f"data[{start}-{end}]"
+        ordered_names.append(name)
         new_process = Process(target=__converter, args=(name, function, dataset, queue, args, kwargs))
         processes.append(new_process)
     
@@ -175,6 +178,9 @@ def iter_flow(function: Callable, data: Collection, *args, **kwargs) -> dict:
     for p in processes:
         q = queue.get()
         results[q[0]] = q[1]
+    
+    if sort_results:
+        results = {k:results[k] for k in ordered_names}
     
     return results
 

--- a/test/test_iter_flow.py
+++ b/test/test_iter_flow.py
@@ -1,0 +1,50 @@
+import pytest
+import numpy as np
+import itertools
+from laminar import laminar
+
+def test_iterflow_basic():
+    """
+    Basic tests from the tutorial.
+    """
+    import numpy as np
+    import pandas as pd
+    from laminar import laminar
+    from laminar import laminar_examples as le
+
+    result = laminar.iter_flow(le.single_total, le.laminar_df['Col1'])
+    assert le.laminar_df['Col1'].sum() == np.sum([x for x in result.values()])
+
+    result = laminar.iter_flow(le.single_total, le.laminar_df['Col1'], odd=True)
+    assert np.sum([x for x in le.laminar_df['Col1'] if x%2 != 0 ]) == np.sum([x for x in result.values()])
+
+def test_iterflow_complex_example():
+    """
+    This is an interesting example because
+    the function foo was not passed directly into iter.flow.
+    """
+    import numpy as np
+    import pandas as pd
+    from laminar import laminar
+
+    reference_list = ["a","b","c","d","e","f","g","h","i","j",
+                      "k","l","m","n","o","p","q","r","s","t","u","v", "w"]
+    iterable_list = [7,4,11,11,14,22,14,17,11,3]
+
+    def foo(x, rl):
+        """
+        >>> foo(0,["A","B","C"])
+        'A'
+        >>> foo(1,["A","B","C"])
+        'B'
+        >>> foo(3,["A","B","C"])
+        IndexError
+        """
+        return(rl[x])
+
+    def wrapfoo(l,rl):
+        return("".join([foo(x,rl) for x in l]))
+
+    result = laminar.iter_flow(wrapfoo, iterable_list, rl = reference_list, cores = 2 )
+    print(result)
+    assert list(result.values()) == ['hello', 'world']

--- a/test/test_iter_flow_complex.py
+++ b/test/test_iter_flow_complex.py
@@ -1,0 +1,94 @@
+import pytest
+from scipy import spatial
+import numpy as np
+import itertools
+from typing import Callable
+import multiprocessing
+from laminar import laminar
+
+def get_pwdist_indices(sequences):
+    """
+    From a list of sequences get lower triangle indices tuples (i,j)
+    for pairwise comparisons.
+
+    Parameters
+    ----------
+    sequences : list of strings
+        list of (likely amino acid) strings
+
+    Returns
+    -------
+    ind_tuples : list
+        ist of tuples (i,j)
+
+    """
+    ind_tuples = []
+    L = len(sequences)
+    for i, j in itertools.product(list(range(L)), list(range(L))):
+        if i <= j:
+            ind_tuples.append((i, j))
+    return(ind_tuples)
+
+def cosine_dist(u: np.ndarray, v:np.ndarray)->float:
+    """Define the cosine distance metric between two numeric vectors u,v"""
+    assert isinstance(u, np.ndarray)
+    assert isinstance(v, np.ndarray)
+    return(spatial.distance.cosine(u, v))
+
+def tuple_to_dist(ij: tuple, matrix: np.ndarray, func: Callable)->float:
+    """ given an ith row and jth row of a matrix apply a distance metric """
+    i = ij[0] # i from tuple
+    j = ij[1] # j from tuple
+    u = matrix[i,] # u-vector is the ith row
+    v = matrix[j,] # v-vector is the jth row
+    return func(matrix[i,], matrix[j,])
+
+def vectorize_tuple_to_dist(ijs:list, matrix:np.ndarray, func: Callable)->list:
+    """vectorize the tuple to dist function."""
+    return [tuple_to_dist(ij, matrix, func) for ij in ijs]
+
+def collapse(iter_flow_result:dict)->list:
+    """ Return iter_flow dict result as a single flat list"""
+    nested_lists = [iter_flow_result[k] for k in iter_flow_result.keys()]
+    flat_list    = [item for sublist in nested_lists for item in sublist]
+    return(flat_list)
+
+def test_in_series(n = 65):
+    """ Test the process in series (no iter.flow)"""
+    mat = np.random.rand(65,5)
+    ijs = get_pwdist_indices(np.arange(65))
+    print(len(ijs))
+    distances = vectorize_tuple_to_dist(ijs, matrix = mat, func = cosine_dist)
+    assert(len(distances) == len(ijs))
+
+testspace = [(10, 2),
+             (30, 2),
+             (50, 2),
+             (65, 2),
+             (10, 4),
+             (30, 4),
+             (50, 4),
+             (65, 4),
+             (10, 8),
+             (30, 8),
+             (50, 8),
+             (65, 8)]
+
+@pytest.mark.parametrize("n, cores", testspace)
+def test_using_laminar_iterflow(n, cores):
+    """ Test the process in parrallel (no iter.flow)"""
+    # Here is the process in series
+    mat = np.random.rand(n,5)
+    ijs = get_pwdist_indices(np.arange(n))
+    distances = vectorize_tuple_to_dist(ijs, matrix = mat, func = cosine_dist)
+    assert(len(distances) == len(ijs))
+
+    r = laminar.iter_flow(function = vectorize_tuple_to_dist,
+                      data = ijs,
+                      matrix = mat,
+                      func = cosine_dist,
+                      cores= cores,
+                      sort_results = True)
+    [print(k) for k in r.keys()]
+    assert np.allclose(collapse(r), distances, atol=1e-3)
+    return(r)


### PR DESCRIPTION
Feel free to ignore this pull request. But for reference, these edits makes it optional to return the data in the order it was delivered. And all the new tests pass:
![Screen Shot 2019-11-12 at 11 30 29 AM](https://user-images.githubusercontent.com/46639063/68703612-d736e900-053f-11ea-9d74-687e2174d12e.png)
